### PR TITLE
Remove escaping and variable expansion from env parser.

### DIFF
--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -54,7 +54,7 @@ LOG=true`)
 		os.Remove(inputFile)
 	}()
 
-	input, err := dotenv.Parse(bytes.NewReader(d), false)
+	input, err := dotenv.Parse(bytes.NewReader(d))
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +102,7 @@ LOG=true`)
 	}
 	defer f.Close()
 
-	results, err := dotenv.Parse(f, false)
+	results, err := dotenv.Parse(f)
 	if err != nil {
 		t.Error(err)
 	}
@@ -136,7 +136,7 @@ LOG=true`)
 		os.Remove(inputFile)
 	}()
 
-	input, err := dotenv.Parse(bytes.NewReader(d), false)
+	input, err := dotenv.Parse(bytes.NewReader(d))
 	if err != nil {
 		t.Error(err)
 	}
@@ -183,7 +183,7 @@ LOG=true`)
 	}
 	defer f.Close()
 
-	results, err := dotenv.Parse(f, false)
+	results, err := dotenv.Parse(f)
 	if err != nil {
 		t.Error(err)
 	}
@@ -217,7 +217,7 @@ LOG=true`)
 		os.Remove(inputFile)
 	}()
 
-	input, err := dotenv.Parse(bytes.NewReader(d), false)
+	input, err := dotenv.Parse(bytes.NewReader(d))
 	if err != nil {
 		t.Error(err)
 	}
@@ -265,7 +265,7 @@ LOG=true`)
 	}
 	defer f.Close()
 
-	results, err := dotenv.Parse(f, false)
+	results, err := dotenv.Parse(f)
 	if err != nil {
 		t.Error(err)
 	}

--- a/component/action/inject.go
+++ b/component/action/inject.go
@@ -95,7 +95,7 @@ func Inject(opt InjectOpt, dep Dep) ([]DownloadedFile, error) {
 			m := map[string]string{}
 
 			if len(remoteKey.Field) > 0 {
-				params, err := dotenv.Parse(bytes.NewReader(result.Data), false)
+				params, err := dotenv.Parse(bytes.NewReader(result.Data))
 				if err != nil {
 					return injected, err
 				}

--- a/component/dotenv/parse.go
+++ b/component/dotenv/parse.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 )
@@ -12,9 +11,6 @@ import (
 const (
 	// Pattern for detecting valid line format
 	linePattern = `\A\s*(?:export\s+)?([\w\.]+)(?:\s*=\s*|:\s+?)('(?:\'|[^'])*'|"(?:\"|[^"])*"|[^#\n]+)?\s*(?:\s*\#.*)?\z`
-
-	// Pattern for detecting valid variable within a value
-	variablePattern = `(\\)?(\$)(\{?([A-Z0-9_]+)?\}?)`
 )
 
 // Env holds key/value pair of valid environment variable
@@ -23,7 +19,7 @@ type Env map[string]string
 // Parse is a function to parse line by line any io.Reader supplied and returns the valid Env key/value pair of valid variables.
 // It expands the value of a variable from the environment variable but does not set the value to the environment itself.
 // This function is returning an error if there are any invalid lines.
-func Parse(r io.Reader, expandVariables bool) (Env, error) {
+func Parse(r io.Reader) (Env, error) {
 	env := make(Env)
 	scanner := bufio.NewScanner(r)
 
@@ -39,7 +35,7 @@ func Parse(r io.Reader, expandVariables bool) (Env, error) {
 
 		i++
 
-		err := parseLine(line, env, expandVariables)
+		err := parseLine(line, env)
 		if err != nil {
 			return env, err
 		}
@@ -48,7 +44,8 @@ func Parse(r io.Reader, expandVariables bool) (Env, error) {
 	return env, nil
 }
 
-func parseLine(s string, env Env, expandVariables bool) error {
+func parseLine(s string, env Env) error {
+
 	rl := regexp.MustCompile(linePattern)
 	rm := rl.FindStringSubmatch(s)
 
@@ -62,9 +59,6 @@ func parseLine(s string, env Env, expandVariables bool) error {
 	// determine if string has quote prefix
 	hdq := strings.HasPrefix(val, `"`)
 
-	// determine if string has single quote prefix
-	hsq := strings.HasPrefix(val, `'`)
-
 	// trim whitespace
 	val = strings.Trim(val, " ")
 
@@ -75,24 +69,10 @@ func parseLine(s string, env Env, expandVariables bool) error {
 	if hdq {
 		val = strings.Replace(val, `\n`, "\n", -1)
 		val = strings.Replace(val, `\r`, "\r", -1)
-
-		// Unescape all characters except $ so variables can be escaped properly
-		re := regexp.MustCompile(`\\([^$])`)
-		val = re.ReplaceAllString(val, "$1")
 	}
-
-	if expandVariables {
-		rv := regexp.MustCompile(variablePattern)
-		fv := func(s string) string {
-			return varReplacement(s, hsq, env)
-		}
-
-		val = rv.ReplaceAllStringFunc(val, fv)
-	}
-
-	val = parseVal(val, env, expandVariables)
 
 	env[key] = val
+
 	return nil
 }
 
@@ -110,33 +90,6 @@ func parseExport(st string, env Env) error {
 	return nil
 }
 
-func varReplacement(s string, hsq bool, env Env) string {
-	if strings.HasPrefix(s, "\\") {
-		return strings.TrimPrefix(s, "\\")
-	}
-
-	if hsq {
-		return s
-	}
-
-	sn := `(\$)(\{?([A-Z0-9_]+)\}?)`
-	rn := regexp.MustCompile(sn)
-	mn := rn.FindStringSubmatch(s)
-
-	if len(mn) == 0 {
-		return s
-	}
-
-	v := mn[3]
-
-	replace, ok := env[v]
-	if !ok {
-		replace = os.Getenv(v)
-	}
-
-	return replace
-}
-
 func checkFormat(s string, env Env) error {
 	st := strings.TrimSpace(s)
 
@@ -149,26 +102,4 @@ func checkFormat(s string, env Env) error {
 	}
 
 	return fmt.Errorf("line `%s` doesn't match format", s)
-}
-
-func parseVal(val string, env Env, expandVariables bool) string {
-	if strings.Contains(val, "=") {
-		if !(val == "\n" || val == "\r") {
-			kv := strings.Split(val, "\n")
-
-			if len(kv) == 1 {
-				kv = strings.Split(val, "\r")
-			}
-
-			if len(kv) > 1 {
-				val = kv[0]
-
-				for i := 1; i < len(kv); i++ {
-					parseLine(kv[i], env, expandVariables)
-				}
-			}
-		}
-	}
-
-	return val
 }

--- a/component/output/transformer_export.go
+++ b/component/output/transformer_export.go
@@ -17,7 +17,7 @@ func (t ExportTransformer) Transform(data []byte) ([]byte, error) {
 		return []byte{}, fmt.Errorf("transformer does not support %s files", t.fileType)
 	}
 
-	params, err := dotenv.Parse(bytes.NewReader(data), false)
+	params, err := dotenv.Parse(bytes.NewReader(data))
 	if err != nil {
 		return data, err
 	}

--- a/component/output/transformer_json.go
+++ b/component/output/transformer_json.go
@@ -23,7 +23,7 @@ func (t JSONTransformer) Transform(data []byte) ([]byte, error) {
 		return []byte{}, fmt.Errorf("transformer does not support %s files", t.fileType)
 	}
 
-	params, err := dotenv.Parse(bytes.NewReader(data), true)
+	params, err := dotenv.Parse(bytes.NewReader(data))
 	if err != nil {
 		return data, err
 	}

--- a/component/output/transformer_taskdefinition.go
+++ b/component/output/transformer_taskdefinition.go
@@ -23,7 +23,7 @@ func (t TaskDefEnvTransformer) Transform(data []byte) ([]byte, error) {
 		Value string `json:"value"`
 	}
 
-	pairs, err := dotenv.Parse(bytes.NewReader(data), true)
+	pairs, err := dotenv.Parse(bytes.NewReader(data))
 	if err != nil {
 		return data, err
 	}

--- a/component/service/parse.go
+++ b/component/service/parse.go
@@ -30,6 +30,6 @@ func (f *File) parseJSON() (map[string]string, error) {
 	return m, nil
 }
 
-func (f *File) parseENV(expandVariables bool) (map[string]string, error) {
-	return dotenv.Parse(bytes.NewReader(f.Data), expandVariables)
+func (f *File) parseENV() (map[string]string, error) {
+	return dotenv.Parse(bytes.NewReader(f.Data))
 }

--- a/component/service/service_parameterstore.go
+++ b/component/service/service_parameterstore.go
@@ -99,7 +99,7 @@ func (s ParameterStoreService) Sync(file File) (File, error) {
 	params := map[string]string{}
 
 	if len(file.Data) > 0 {
-		p, err := dotenv.Parse(bytes.NewReader(file.Data), false)
+		p, err := dotenv.Parse(bytes.NewReader(file.Data))
 		if err != nil {
 			return file, fmt.Errorf("file invalid: %s", err)
 		}

--- a/component/service/service_secretsmanager.go
+++ b/component/service/service_secretsmanager.go
@@ -696,7 +696,7 @@ func toMap(f *File) (map[string]string, error) {
 	switch f.Type {
 	case file.TypeEnv:
 		if v, ok := f.Options[SMSecretsOption]; !ok || v == SMSecretsSingle {
-			props, err := f.parseENV(false)
+			props, err := f.parseENV()
 			if err != nil {
 				return map[string]string{}, err
 			}
@@ -730,7 +730,7 @@ func toMap(f *File) (map[string]string, error) {
 }
 
 func envToMap(f *File, delimiter string) (map[string]string, error) {
-	props, err := f.parseENV(false)
+	props, err := f.parseENV()
 	if err != nil {
 		return map[string]string{}, err
 	}

--- a/get.go
+++ b/get.go
@@ -83,7 +83,7 @@ func GetMap(opt GetOptions) (map[string]string, error) {
 
 	m := map[string]string{}
 	for _, d := range downloads {
-		tm, err := dotenv.Parse(bytes.NewReader(d.Data), false)
+		tm, err := dotenv.Parse(bytes.NewReader(d.Data))
 		if err != nil {
 			return m, err
 		}


### PR DESCRIPTION
When parsing env files, the escape character `\` is removed from the values, and environment variables are expanded. This functionality may not be necessary for Stash. 